### PR TITLE
Refactor a bit and add some new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#RedisScan
+# RedisScan
 
 Recursively scans the keyspace of a Redis 2.8+ instance using SCAN, HSCAN, ZSCAN, & SSCAN as well as Lists.
 
@@ -8,17 +8,17 @@ Optionally pass a redis pattern to filter from.
 
 `scanRedis(args)`
 
-args:
+### args (simple object):
 
-* redis: node-redis instance (required)
-* pattern: optional wildcard key pattern
-* keys_only: optional boolean -- returns nothing but keys, no types,lengths,values etc. (defaults to `false`)
-* each\_callback: function (type, key, subkey, length, value, finish\_callback)
+* `redis`: `node-redis` instance (required)
+* `pattern`: optional wildcard key pattern to match, e.g: `some:key:pattern:*` [redis MATCH docs](https://redis.io/commands/scan#the-match-option)
+* `keys_only`: optional boolean -- returns nothing but keys, no types,lengths,values etc. (defaults to `false`)
+* `each_callback`: function (type, key, subkey, length, value, finish\_callback)
     type may be string, hash, set, zset, list
     call finish\_callback when done
-* done\_callback: called when done scanning
+* `done_callback`: called when done scanning
 
-each\_callback is called for every string, and every subkey/value in a container, so container keys may be called multiple times.
+`each_callback` is called for every string, and every subkey/value in a container when not using `keys_only`, so container keys may be called multiple times.
 
 Example: 
 
@@ -29,6 +29,7 @@ var redis     = require('redis').createClient();
 
 redisScan({
     redis: redis,
+    keys_only: false,
     each_callback: function (type, key, subkey, length, value, cb) {
         console.log(type, key, subkey, length, value);
         cb();

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ redisScan({
 * `pattern`: **optional** wildcard key pattern to match, e.g: `some:key:pattern:*` [docs](https://redis.io/commands/scan#the-match-option)
 * `keys_only`: **optional** boolean -- returns nothing but keys, no types,lengths,values etc. (defaults to `false`)
 * `count_amt`: **optional** positive/non-zero integer -- redis hint for work done per SCAN operation (defaults to 10) [docs](https://redis.io/commands/scan#the-count-option)
-* `each_callback`: **required** `function (type, key, subkey, length, value, finish_callback)`  This is called for every string, and every subkey/value in a container when not using `keys_only`, so outer keys may show up multiple times.
+* `each_callback`: **required** `function (type, key, subkey, length, value, next)`  This is called for every string, and every subkey/value in a container when not using `keys_only`, so outer keys may show up multiple times.
     * `type` may be `"string"`, `"hash"`, `"set"`, `"zset"`, `"list"`
     * `key` is the redis key
     * `subkey` may be `null` or populated with a hash key
     * `length` is the length of a set or list
     * `value` is the value of the key or subkey when appropriate
-    * `finish_callback` should be called as a function with no arguments if successful or an `Error` object if not.
+    * `next()` should be called as a function with no arguments if successful or an `Error` object if not.
 * `done_callback`: **optional** function called when scanning completes with one argument, and `Error` object if an error ws raised
 
 ## Note/Warning

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ args:
 
 * redis: node-redis instance (required)
 * pattern: optional wildcard key pattern
-* each\_callback: function (type, key, subkey, value, finish\_callback)
+* keys_only: optional boolean -- returns nothing but keys, no types,lengths,values etc. (defaults to `false`)
+* each\_callback: function (type, key, subkey, length, value, finish\_callback)
     type may be string, hash, set, zset, list
     call finish\_callback when done
 * done\_callback: called when done scanning
@@ -28,8 +29,8 @@ var redis     = require('redis').createClient();
 
 redisScan({
     redis: redis,
-    each_callback: function (type, key, subkey, value, cb) {
-        console.log(type, key, subkey, value);
+    each_callback: function (type, key, subkey, length, value, cb) {
+        console.log(type, key, subkey, length, value);
         cb();
     },
     done_callback: function (err) {

--- a/README.md
+++ b/README.md
@@ -6,21 +6,10 @@ Fairly safe in a production environment as it does **NOT** use KEYS * to iterate
 
 Optionally pass a redis pattern to filter from.
 
-`scanRedis(args)`
+## Install
+`npm install redisscan`
 
-### args (simple object):
-
-* `redis`: `node-redis` instance (required)
-* `pattern`: optional wildcard key pattern to match, e.g: `some:key:pattern:*` [redis MATCH docs](https://redis.io/commands/scan#the-match-option)
-* `keys_only`: optional boolean -- returns nothing but keys, no types,lengths,values etc. (defaults to `false`)
-* `each_callback`: function (type, key, subkey, length, value, finish\_callback)
-    type may be string, hash, set, zset, list
-    call finish\_callback when done
-* `done_callback`: called when done scanning
-
-`each_callback` is called for every string, and every subkey/value in a container when not using `keys_only`, so container keys may be called multiple times.
-
-Example: 
+## Example 
 
 ```javascript
 var redisScan = require('redisscan');
@@ -29,6 +18,7 @@ var redis     = require('redis').createClient();
 
 redisScan({
     redis: redis,
+    pattern: 'awesome:key:prefix:*',
     keys_only: false,
     each_callback: function (type, key, subkey, length, value, cb) {
         console.log(type, key, subkey, length, value);
@@ -40,12 +30,27 @@ redisScan({
     }
 });
 ```
+
+### redisScan(parameters):
+
+* `redis`: **required** `node-redis` client instance 
+* `pattern`: **optional** wildcard key pattern to match, e.g: `some:key:pattern:*` [docs](https://redis.io/commands/scan#the-match-option)
+* `keys_only`: **optional** boolean -- returns nothing but keys, no types,lengths,values etc. (defaults to `false`)
+* `count_amt`: **optional** positive/non-zero integer -- redis hint for work done per SCAN operation (defaults to 10) [docs](https://redis.io/commands/scan#the-count-option)
+* `each_callback`: **required** `function (type, key, subkey, length, value, finish_callback)`  This is called for every string, and every subkey/value in a container when not using `keys_only`, so outer keys may show up multiple times.
+    * `type` may be `"string"`, `"hash"`, `"set"`, `"zset"`, `"list"`
+    * `key` is the redis key
+    * `subkey` may be `null` or populated with a hash key
+    * `length` is the length of a set or list
+    * `value` is the value of the key or subkey when appropriate
+    * `finish_callback` should be called as a function with no arguments if successful or an `Error` object if not.
+* `done_callback`: **optional** function called when scanning completes with one argument, and `Error` object if an error ws raised
+
 ## Note/Warning
 
 If values are changing, there is no guarantee on value integrity. This is not atomic.
 I recommend using a lock pattern with this function.
 
-## Install
-`npm install redisscan`
+
 
 License MIT (c) 2014 Nathanael C. Fritz

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 var async = require('async');
-var redis, pattern, keys_only, each_callback;
+var redis, pattern, keys_only, count_amt, each_callback;
 
 module.exports = function (args) {
     redis            = args.redis;
     pattern          = args.pattern || pattern;
     keys_only        = args.keys_only;
+    count_amt        = args.count_amt;
     each_callback    = args.each_callback;
 
     genericScan(args.cmd, args.key, args.done_callback);
@@ -24,6 +25,9 @@ var genericScan = function(cmd, key, callback) {
             if (cmd === 'SCAN') {
                 if (pattern) {
                     args = args.concat(['MATCH', pattern]);
+                }
+                if (count_amt){
+                    args = args.concat(['COUNT', count_amt]);
                 }
             } else {
                 args = [key].concat(args);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,21 @@
 var async = require('async');
+var redis, pattern, keys_only, each_callback;
 
-function genericScan(redis, cmd, key, pattern, each_callback, done_callback) {
+module.exports = function (args) {
+    redis            = args.redis;
+    pattern          = args.pattern || pattern;
+    keys_only        = args.keys_only;
+    each_callback    = args.each_callback;
+
+    genericScan(args.cmd, args.key, args.done_callback);
+};
+
+var genericScan = function(cmd, key, callback) {
+
+    cmd      = cmd || 'SCAN';
+    key      = key || null;
+    callback = callback || function(){};
+
     var iter = '0';
     async.doWhilst(
         function (acb) {
@@ -14,6 +29,7 @@ function genericScan(redis, cmd, key, pattern, each_callback, done_callback) {
                 args = [key].concat(args);
             }
             redis.send_command(cmd, args, function (err, result) {
+
                 var idx = 0;
                 var keys;
                 if (err) {
@@ -23,34 +39,37 @@ function genericScan(redis, cmd, key, pattern, each_callback, done_callback) {
                     iter = result[0];
                     //each key, limit to 5 pending callbacks at a time
                     if (['SCAN', 'SSCAN'].indexOf(cmd) !== -1) {
-                        async.eachSeries(result[1], function (subkey, ecb) {
-                            if (cmd === 'SCAN') {
+
+                        async.eachSeries(result[1], function (subkey, next) {
+                            if (keys_only){
+                                each_callback(null, subkey, null, null, null, next);
+                            } else if (cmd === 'SCAN') {
                                 redis.type(subkey, function (err, sresult) {
                                     var value;
                                     if (err) {
-                                        ecb(err);
+                                        next(err);
                                     } else {
                                         if (sresult === 'string') {
                                             redis.get(subkey, function (err, value) {
                                                 if (err) {
-                                                    ecb(err);
+                                                    next(err);
                                                 } else {
-                                                    each_callback('string', subkey, null, null, value, ecb);
+                                                    each_callback('string', subkey, null, null, value, next);
                                                 }
                                             });
                                         } else if (sresult === 'hash') {
-                                            genericScan(redis, 'HSCAN', subkey, null, each_callback, ecb);
+                                            genericScan('HSCAN', subkey, next);
                                         } else if (sresult === 'set') {
-                                            genericScan(redis, 'SSCAN', subkey, null, each_callback, ecb);
+                                            genericScan('SSCAN', subkey, next);
                                         } else if (sresult === 'zset') {
-                                            genericScan(redis, 'ZSCAN', subkey, null, each_callback, ecb);
+                                            genericScan('ZSCAN', subkey, next);
                                         } else if (sresult === 'list') {
-                                            //each_callback('list', subkey, null, null, ecb);
+                                            //each_callback('list', subkey, null, null, next);
                                             redis.llen(subkey, function (err, length) {
                                                 var idx = 0;
                                                 length = parseInt(length);
                                                 if (err) {
-                                                    ecb(err);
+                                                    next(err);
                                                 } else {
                                                     async.doWhilst(
                                                         function (wcb) {
@@ -60,7 +79,7 @@ function genericScan(redis, cmd, key, pattern, each_callback, done_callback) {
                                                         },
                                                         function () { idx++; return idx < length; },
                                                         function (err) {
-                                                            ecb(err)
+                                                            next(err);
                                                         }
                                                     );
                                                 }
@@ -69,7 +88,7 @@ function genericScan(redis, cmd, key, pattern, each_callback, done_callback) {
                                     }
                                 });
                             } else if (cmd === 'SSCAN') {
-                                each_callback('set', key, idx, null, subkey, ecb);
+                                each_callback('set', key, idx, null, subkey, next);
                             }
                             idx++;
                         },
@@ -78,18 +97,18 @@ function genericScan(redis, cmd, key, pattern, each_callback, done_callback) {
                             acb(err);
                         });
                     } else {
-                        var idx = 0;
+                        var idx2 = 0;
                         async.doWhilst(
                             function (ecb) {
-                                var subkey = result[1][idx];
-                                var value = result[1][idx+1];
+                                var subkey = result[1][idx2];
+                                var value = result[1][idx2+1];
                                 if (cmd === 'HSCAN') {
                                     each_callback('hash', key, subkey, null, value, ecb);
                                 } else if (cmd === 'ZSCAN') {
                                     each_callback('zset', key, value, null, subkey, ecb);
                                 }
-                            }, 
-                            function () {idx += 2; return idx < result[1].length;},
+                            },
+                            function () {idx2 += 2; return idx2 < result[1].length;},
                             function (err) {
                                 acb(err);
                             }
@@ -102,12 +121,11 @@ function genericScan(redis, cmd, key, pattern, each_callback, done_callback) {
         function () { return iter != '0'; },
         //done
         function (err) {
-            done_callback(err);
+            callback(err);
+            // done_callback(err);
         }
     );
-}
-
-module.exports = function (args) {
-    genericScan(args.redis, args.cmd || 'SCAN', args.key || null, args.pattern, args.each_callback, args.done_callback);
 };
+
+
 

--- a/package.json
+++ b/package.json
@@ -8,12 +8,20 @@
   },
   "description": "Scan through all redis keys and containers, calling back each value individually.",
   "dependencies": {
-    "redis": "~0.10.0",
+    "redis": "^2.7.1",
     "async": "~0.2.10"
   },
   "devDependencies": {
     "precommit-hook": "*"
   },
-  "scripts": {},
-  "main": "index.js"
+  "scripts": {
+    "lint": "jshint .",
+    "validate": "npm ls"
+  },
+  "main": "index.js",
+  "pre-commit": [
+    "lint",
+    "validate",
+    "test"
+  ]
 }

--- a/test.js
+++ b/test.js
@@ -3,8 +3,8 @@ var redis       = require('redis').createClient();
 
 redisScan({
     redis: redis,
-    each_callback: function (type, key, subkey, value, cb) {
-        console.log(type, key, subkey, value);
+    each_callback: function (type, key, subkey, length, value, cb) {
+        console.log(type, key, subkey, length, value);
         cb();
     },
     done_callback: function (err) {


### PR DESCRIPTION
- Update docs to match current callback signatures as well as newly added arguments and generally clean up a bit for readability
- Provide a way to SCAN without deep-diving into the values of the keys via the `keys_only` argument.
- Provide an optional argument `count_amt` to manually set the `COUNT` value sent to Redis for faster bulk scans
- Reduce signature size of `genericScan` to require fewer arguments on each call
- Update examples and tests to account for `length` return arguments